### PR TITLE
Add support for API-based circle and user management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,11 +87,18 @@
             <version>7.12.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.3.1</version> <!-- or the latest -->
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/test/java/steps/CreateCircleSteps.java
+++ b/src/test/java/steps/CreateCircleSteps.java
@@ -71,4 +71,14 @@ public class CreateCircleSteps {
     public void passcodeFieldContains(String passcode) {
         createCirclePage.assertCreateCirclePasscodeFieldInput(passcode);
     }
+
+    @And("they enter a new email in the email field on the Create Circle page")
+    public void theyEnterANewUserEmailInTheEmailFieldOnTheCreateCirclePage() {
+        createCirclePage.enterEmailOnCreateCirclePage(PropertiesLoader.getProperties("newCircleEmail"));
+    }
+
+    @And("they enter new password in the password field on the Create Circle page")
+    public void theyEnterNewPasswordInThePasswordFieldOnTheCreateCirclePage() {
+        createCirclePage.enterPasswordOnCreateCirclePage(PropertiesLoader.getProperties("newCirclePassword"));
+    }
 }

--- a/src/test/java/steps/SignInSteps.java
+++ b/src/test/java/steps/SignInSteps.java
@@ -40,6 +40,11 @@ public class SignInSteps {
         signInPage.enterEmailOnSignInPage();
     }
 
+    @And("they enter new circle email in Email input field on Login page")
+    public void theyEnterNewCircleEmailInEmailInputFieldOnLoginPage() {
+        signInPage.enterEmailOnSignInPage(PropertiesLoader.getProperties("newCircleEmail"));
+    }
+
     @And("they enter {string} in Password input field on Login page")
     public void theyEnterInPasswordInputFieldOnLoginPage(String password) {
         signInPage.enterPasswordOnSignInPage(password);
@@ -87,5 +92,10 @@ public class SignInSteps {
     @And("they enter valid password in Password input field on Login page")
     public void theyEnterValidPasswordInPasswordInputFieldOnLoginPage() {
         signInPage.enterPasswordOnSignInPage(PropertiesLoader.getProperties("password"));
+    }
+
+    @And("they enter new circle password in Password input field on Login page")
+    public void theyEnterNewCirclePasswordInPasswordInputFieldOnLoginPage() {
+        signInPage.enterPasswordOnSignInPage(PropertiesLoader.getProperties("newCirclePassword"));
     }
 }

--- a/src/test/java/tools/ApiHelper.java
+++ b/src/test/java/tools/ApiHelper.java
@@ -1,0 +1,100 @@
+package tools;
+
+import io.restassured.filter.cookie.CookieFilter;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class ApiHelper {
+    private final CookieFilter cookieFilter = new CookieFilter();
+
+    public String getCsrfToken() {
+        Response response =
+        given()
+                .filter(cookieFilter)
+                .baseUri(PropertiesLoader.getProperties("apiBaseUrl"))
+        .when()
+                .get(PropertiesLoader.getProperties("csrfToken.endpoint"))
+        .then()
+                .extract().response();
+
+        return response.jsonPath().getString("csrfToken");
+    }
+
+    public Map<String, String> login(String email, String plainPassword, String csrfToken) {
+        String encodedPassword = Base64.getEncoder()
+                .encodeToString(plainPassword.getBytes(StandardCharsets.UTF_8));
+
+        Response loginResponse =
+        given()
+                .filter(cookieFilter)
+                .baseUri(PropertiesLoader.getProperties("apiBaseUrl"))
+                .contentType("application/x-www-form-urlencoded; charset=UTF-8")
+                .accept("application/json")
+                .formParam("csrfToken", csrfToken)
+                .formParam("email", email)
+                .formParam("password", encodedPassword)
+                .formParam("redirect", "false")
+                .formParam("json", "true")
+                .formParam("callbackUrl", PropertiesLoader.getProperties("signInUrl"))
+        .when()
+                .post(PropertiesLoader.getProperties("login.endpoint"));
+
+        return loginResponse.getCookies();
+    }
+
+    public void deleteCircle(Map<String, String> cookies) {
+        given()
+                .baseUri(PropertiesLoader.getProperties("apiBaseUrl"))
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .cookies(cookies)
+                .body("{}")
+        .when()
+                .delete(PropertiesLoader.getProperties("circle.endpoint"))
+        .then()
+                .statusCode(200);
+    }
+
+    public String getUserIdByEmail(String email) {
+        Response response =
+        given()
+                .filter(cookieFilter)
+                .baseUri(PropertiesLoader.getProperties("apiBaseUrl"))
+        .when()
+                .get(PropertiesLoader.getProperties("users.endpoint"))
+        .then()
+                .extract().response();
+
+        List<Map<String, Object>> users = response.jsonPath().getList("");
+
+        for (Map<String, Object> user : users) {
+            if (email.equals(user.get("email"))) {
+                return (String) user.get("id");
+            }
+        }
+        return null;
+    }
+
+    public void deleteUserById(String userId) {
+        Map<String, String> requestBody = new HashMap<>();
+        requestBody.put("id", userId);
+
+        given()
+                .filter(cookieFilter)
+                .baseUri(PropertiesLoader.getProperties("apiBaseUrl"))
+                .contentType(ContentType.JSON)
+                .body(requestBody)
+        .when()
+                .delete(PropertiesLoader.getProperties("users.endpoint") )
+        .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -5,6 +5,7 @@ browser=chrome
 signInUrl=http://opencircle.us/login
 joinCircleUrl=http://opencircle.us/join
 createCircleUrl=http://opencircle.us/create
+apiBaseUrl=http://opencircle.us/api
 
 # Home page variables
 circleName=Bootcamp2025
@@ -12,3 +13,9 @@ circleName=Bootcamp2025
 #Messages
 successfulMessage=Success
 warningMessage=Warning
+
+# API endpoints
+csrfToken.endpoint=/auth/csrf
+login.endpoint=/auth/callback/login
+circle.endpoint=/circles
+users.endpoint=/users

--- a/src/test/resources/features/create_circle.feature
+++ b/src/test/resources/features/create_circle.feature
@@ -27,6 +27,7 @@ Feature: Create Circle
       | passcode |
       | Abcd12@  |
 
+
   Scenario Outline:  Pushing copy button while passcode field is empty
       Given a user opens Create Circle page
       And they click copy button
@@ -34,3 +35,20 @@ Feature: Create Circle
       Examples:
         | error popup               |
         | Generate PassCode firstly |
+
+
+  @DeleteCircle
+  Scenario: New circle is created, and user is logged into the newly created circle
+    Given a user opens Create Circle page
+    When they enter "TestCircle2025" in the Circle name field on the Create Circle page
+    And they click the Generate button on the Create Circle page
+    And they enter "FirstName" in the First Name field on the Create Circle Page
+    And they enter "LastName" in the Last Name field on the Create Circle page
+    And they enter a new email in the email field on the Create Circle page
+    And they enter new password in the password field on the Create Circle page
+    And they click the Create button on the Create Circle page
+    Then they see a success popup message "You have successfully registered."
+    And they enter new circle email in Email input field on Login page
+    And they enter new circle password in Password input field on Login page
+    And they click Sign In button on Login page
+    And they verify that they are on Circle Home page


### PR DESCRIPTION
- Implement `ApiHelper` for handling API interactions (CSRF, login, delete circle/user).
- Extend test steps and scenarios to use new email/password properties for circle creation and login.
- Update `TearDown` for API-based cleanup after scenarios.
- Configure Rest-Assured dependency and Java 17 compatibility in `pom.xml`.